### PR TITLE
Moving the data folder outside the package itself 

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -40,7 +40,7 @@
     var inited = false,
         sessionStarted = false,
         platform,
-        filePath = path.join(os.tmpdir(), "countly-sdk-nodejs", "data/"),
+        filePath = path.join(os.tmpdir(), "countly-sdk-nodejs"),
         apiPath = "/i",
         beatInterval = 500,
         queueSize = 1000,

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -40,7 +40,7 @@
     var inited = false,
         sessionStarted = false,
         platform,
-        filePath = path.join(os.tmpdir(), "countly-sdk-nodejs", "data/",
+        filePath = path.join(os.tmpdir(), "countly-sdk-nodejs", "data/"),
         apiPath = "/i",
         beatInterval = 500,
         queueSize = 1000,

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -40,7 +40,7 @@
     var inited = false,
         sessionStarted = false,
         platform,
-        filePath = "../data/",
+        filePath = path.join(os.tmpdir(), "countly-sdk-nodejs", "data/",
         apiPath = "/i",
         beatInterval = 500,
         queueSize = 1000,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "countly-sdk-nodejs",
-  "version": "17.09.0",
+  "version": "17.09.1",
   "description": "Countly NodeJS SDK",
   "main": "lib/countly.js",
   "directories": {


### PR DESCRIPTION
There are a few scenarios where no data can be created in the module directory, one of which is when using something like [Zeit's pkg](https://github.com/zeit/pkg), as the modules themselves become immutable at that point.

For this particular PR, I simply moved the data folder to `/tmp/countly-sdk-nodejs`, where `/tmp` comes from `os.tmpdir()`, so it should be platform specific.