### PR TITLE
fix: mkdir recursive of storage_path

### DIFF
--- a/lib/countly.js
+++ b/lib/countly.js
@@ -154,7 +154,7 @@ Countly.Bulk = Bulk;
             var dir = path.resolve(__dirname, Countly.storage_path);
             try {
                 if (!fs.existsSync(dir)) {
-                    fs.mkdirSync(dir);
+                    fs.mkdirSync(dir, { recursive: true });
                 }
             }
             catch (ex) {


### PR DESCRIPTION
needed to set storage_path outside of (read-only) node_modules
