### PR TITLE
[SDK-565] Consent reset with newId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+## 21.11.0
+- !! Major breaking change !! Changing device ID without merging will now clear the current consent. Consent has to be given again after performing this action.
+- Increased the default max event batch size to 100.
+
+## 20.11
+- Add javascript flag to reported errors
+- Added explicit remote-config consent
+- Async writes with queue and lock
+- Fixed bulk example
+- Stricter Eslint rules
+
+## 20.04
+- Add basic performance trace reporting option
+- Add method to report feedback directly without dialog (for custom UI)
+- Allow providing custom segments for view tracking
+
+## 19.08
+- Allow overriding http options for each separate request to use proxy and other options
+
+## 19.02
+- Add remote config support
+- Handle http request fail correctly
+- Report unhandled rejections too
+
+## 18.08
+- Add crash log breadcrumb limit
+- Allow unsetting custom property
+- Empty event queue (into request queue) on device_id change (if user is not merged on server)
+- Fixed consent check in Bulk Users
+- Fixed consent check in Countly
+- Fixed log for timed events
+- Fixed logging in Bulk Users
+
+## 18.04
+- Add GDPR compliant consent management
+- Allow providing path to storing internal data as initial configuration option
+- Generate docs for CountlyBulk api
+- Git ignore internally stored files
+
+## 17.09
+- Added bulk request processor for server to server data flow
+- Synchronized persistent storage in some cases
+
+## 17.05
+- Do not override provided metrics
+- Improved comments and docs
+
+## 16.12.1
+- Some minor changes
+
+## 16.12
+- Added new configuration options, as session_update and max_events, force_post
+- Automatic switch to POST if amount of data can't be handled by GET
+- Correctly handle ending session on device_id change without merge
+- Additional checks preventing possible crashes
+- Use unique millisecond timestamp for reporting
+
+## 16.06
+- First official release compatible with Countly Server 16.06 functionalities

--- a/lib/countly-bulk-user.js
+++ b/lib/countly-bulk-user.js
@@ -171,22 +171,29 @@ function CountlyBulkUser(conf) {
     /**
     * Remove consent for specific feature, meaning, user opted out to track that data (either core feature of from custom feature group)
     * @param {string|array} feature - name of the feature, possible values, "sessions","events","views","crashes","attribution","users" or customly provided through {@link CountlyBulkUser.group_features}
+    * @param {Boolean} enforceConsentUpdate - regulates if a request will be sent to the server or not. If true, removing consents will send a request to the server and if false, consents will be removed without a request 
     */
     this.remove_consent = function(feature) {
         log("Removing consent for " + feature);
-        if (feature.constructor === Array) {
+        this.remove_consent_internal(feature, true);
+    }    
+    //removes consent without updating
+    this.remove_consent_internal = function(feature, enforceConsentUpdate) {
+        //if true updateConsent will execute when possible
+        enforceConsentUpdate = enforceConsentUpdate || false; 
+            if (feature.constructor === Array) {
             for (var i = 0; i < feature.length; i++) {
-                this.remove_consent(feature[i]);
+                this.remove_consent_internal(feature[i], enforceConsentUpdate);
             }
         }
         else if (consents[feature]) {
             if (consents[feature].features) {
                 //this is added group, let's iterate through sub features
-                this.remove_consent(consents[feature].features);
+                this.remove_consent_internal(consents[feature].features, enforceConsentUpdate);
             }
             else {
                 //this is core feature
-                if (consents[feature].optin !== false) {
+                if (enforceConsentUpdate && consents[feature].optin !== false) {
                     syncConsents[feature] = false;
                     updateConsent();
                 }

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -318,27 +318,35 @@ Countly.Bulk = Bulk;
     /**
     * Remove consent for specific feature, meaning, user opted out to track that data (either core feature of from custom feature group)
     * @param {string|array} feature - name of the feature, possible values, "sessions","events","views","crashes","attribution","users" or customly provided through {@link Countly.group_features}
+    * @param {Boolean} enforceConsentUpdate - regulates if a request will be sent to the server or not. If true, removing consents will send a request to the server and if false, consents will be removed without a request 
     */
     Countly.remove_consent = function(feature) {
         log("Removing consent for " + feature);
+        Countly.remove_consent_internal(feature, true);
+    }
+    //removes consent without updating
+    Countly.remove_consent_internal = function(feature, enforceConsentUpdate) {
+        //if true updateConsent will execute when possible
+        enforceConsentUpdate = enforceConsentUpdate || false;    
         if (feature.constructor === Array) {
             for (var i = 0; i < feature.length; i++) {
-                Countly.remove_consent(feature[i]);
+                Countly.remove_consent_internal(feature[i], enforceConsentUpdate);
             }
         }
         else if (consents[feature]) {
             if (consents[feature].features) {
                 //this is added group, let's iterate through sub features
-                Countly.remove_consent(consents[feature].features);
+                Countly.remove_consent_internal(consents[feature].features, enforceConsentUpdate);
             }
             else {
                 //this is core feature
-                if (consents[feature].optin !== false) {
+                if (enforceConsentUpdate && consents[feature].optin !== false) {
                     syncConsents[feature] = false;
                     updateConsent();
                 }
             }
             consents[feature].optin = false;
+
         }
         else {
             log("No feature available for " + feature);
@@ -434,6 +442,8 @@ Countly.Bulk = Bulk;
                     Countly.end_session();
                     //clear timed events
                     timedEvents = {};
+                    //clear all consents
+                    Countly.remove_consent_internal(Countly.features, false);
                 }
                 var oldId = Countly.device_id;
                 Countly.device_id = newId;


### PR DESCRIPTION
- Created internal removal function
- Removing consent during non-merge id change
- Tested and working
- Changelog entry

![image](https://user-images.githubusercontent.com/62231246/143839364-016579d4-849f-4d44-91f5-8fabe2ad9282.png)
Log output for erased consents. (another log, for if requests were sent never triggered)
![image](https://user-images.githubusercontent.com/62231246/143839642-02a242b8-7ecf-417e-a896-b365ede10f7c.png)
ID changed to boba fett