### PR TITLE
[SDK-448] Internal consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+## 21.11.0
+- !! Major breaking change !! Changing device ID without merging will now clear the current consent. Consent has to be given again after performing this action.
+- When recording internal events with 'add_event', the respective feature consent will now be checked instead of just the 'events' consent. 
+- Increased the default max event batch size to 100.
+
+## 20.11
+- Add javascript flag to reported errors
+- Added explicit remote-config consent
+- Async writes with queue and lock
+- Fixed bulk example
+- Stricter Eslint rules
+
+## 20.04
+- Add basic performance trace reporting option
+- Add method to report feedback directly without dialog (for custom UI)
+- Allow providing custom segments for view tracking
+
+## 19.08
+- Allow overriding http options for each separate request to use proxy and other options
+
+## 19.02
+- Add remote config support
+- Handle http request fail correctly
+- Report unhandled rejections too
+
+## 18.08
+- Add crash log breadcrumb limit
+- Allow unsetting custom property
+- Empty event queue (into request queue) on device_id change (if user is not merged on server)
+- Fixed consent check in Bulk Users
+- Fixed consent check in Countly
+- Fixed log for timed events
+- Fixed logging in Bulk Users
+
+## 18.04
+- Add GDPR compliant consent management
+- Allow providing path to storing internal data as initial configuration option
+- Generate docs for CountlyBulk api
+- Git ignore internally stored files
+
+## 17.09
+- Added bulk request processor for server to server data flow
+- Synchronized persistent storage in some cases
+
+## 17.05
+- Do not override provided metrics
+- Improved comments and docs
+
+## 16.12.1
+- Some minor changes
+
+## 16.12
+- Added new configuration options, as session_update and max_events, force_post
+- Automatic switch to POST if amount of data can't be handled by GET
+- Correctly handle ending session on device_id change without merge
+- Additional checks preventing possible crashes
+- Use unique millisecond timestamp for reporting
+
+## 16.06
+- First official release compatible with Countly Server 16.06 functionalities

--- a/lib/countly-bulk-user.js
+++ b/lib/countly-bulk-user.js
@@ -337,7 +337,6 @@ function CountlyBulkUser(conf) {
             respectiveConsent = this.check_consent('clicks') || this.check_consent('scroll');
             break;
         default:
-            respectiveConsent = false;
             respectiveConsent = this.check_consent('events');
         }
 

--- a/lib/countly-bulk-user.js
+++ b/lib/countly-bulk-user.js
@@ -50,7 +50,25 @@ function CountlyBulkUser(conf) {
     * Array with list of available features that you can require consent for
     */
     var features = ["sessions", "events", "views", "crashes", "attribution", "users", "star-rating", "location", "apm", "feedback", "remote-config"];
-
+    /**
+     * At the current moment there are following internal events and their respective required consent:
+        [CLY]_nps - "feedback" consent
+        [CLY]_survey - "feedback" consent
+        [CLY]_star_rating - "star_rating" consent
+        [CLY]_view - "view" consent
+        [CLY]_orientation - "users" consent
+        [CLY]_push_action - "push" consent
+        [CLY]_action - "clicks" or "scroll" consent
+     */
+    var internalEventKeyEnums = {
+        NPS: '[CLY]_nps',
+        SURVEY: '[CLY]_survey',
+        STAR_RATING: '[CLY]_star_rating',
+        VIEW: '[CLY]_view',
+        ORIENTATION: '[CLY]_orientation',
+        PUSH_ACTION: '[CLY]_push_action',
+        ACTION: '[CLY]_action',
+    };
     //create object to store consents
     var consents = {};
     for (var feat = 0; feat < features.length; feat++) {
@@ -293,8 +311,39 @@ function CountlyBulkUser(conf) {
     * @returns {module:lib/countly-bulk-user} instance
     **/
     this.add_event = function(event) {
-        if (this.check_consent("events")) {
+        //initially no consent is given
+        var respectiveConsent = false;
+        //to match the internal events and their respective required consents. Sets respectiveConsent to true if the consent is given
+        switch (event.key) {
+        case internalEventKeyEnums.NPS:
+            respectiveConsent = this.check_consent('feedback');
+            break;
+        case internalEventKeyEnums.SURVEY:
+            respectiveConsent = this.check_consent('feedback');
+            break;
+        case internalEventKeyEnums.STAR_RATING:
+            respectiveConsent = this.check_consent('star-rating');
+            break;
+        case internalEventKeyEnums.VIEW:
+            respectiveConsent = this.check_consent('view');
+            break;
+        case internalEventKeyEnums.ORIENTATION:
+            respectiveConsent = this.check_consent('users');
+            break;
+        case internalEventKeyEnums.PUSH_ACTION:
+            respectiveConsent = this.check_consent('push');
+            break;
+        case internalEventKeyEnums.ACTION:
+            respectiveConsent = this.check_consent('clicks') || this.check_consent('scroll');
+            break;
+        default:
+            respectiveConsent = false;
+            respectiveConsent = this.check_consent('events');
+        }
+
+        if (respectiveConsent) {
             conf.server.add_event(conf.device_id, event);
+
         }
         return this;
     };
@@ -366,7 +415,7 @@ function CountlyBulkUser(conf) {
     this.report_view = function(view_name, timestamp, duration, viewSegments) {
         if (this.check_consent("views")) {
             var event = {
-                "key": "[CLY]_view",
+                "key": internalEventKeyEnums.VIEW,
                 "dur": duration,
                 "count": 1,
                 "segmentation": {
@@ -421,7 +470,7 @@ function CountlyBulkUser(conf) {
             if (this.check_consent("events")) {
                 var props = ["widget_id", "contactMe", "platform", "app_version", "rating", "email", "comment"];
                 var event = {
-                    key: "[CLY]_star_rating",
+                    key: internalEventKeyEnums.STAR_RATING,
                     count: 1,
                     segmentation: {}
                 };

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -519,7 +519,6 @@ Countly.Bulk = Bulk;
             respectiveConsent = Countly.check_consent('clicks') || Countly.check_consent('scroll');
             break;
         default:
-            respectiveConsent = false;
             respectiveConsent = Countly.check_consent('events');
         }
         //if consent is given adds event to the queue

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -74,7 +74,25 @@ Countly.Bulk = Bulk;
     * Array with list of available features that you can require consent for
     */
     Countly.features = ["sessions", "events", "views", "crashes", "attribution", "users", "location", "star-rating", "apm", "feedback", "remote-config"];
-
+    /**
+     * At the current moment there are following internal events and their respective required consent:
+        [CLY]_nps - "feedback" consent
+        [CLY]_survey - "feedback" consent
+        [CLY]_star_rating - "star_rating" consent
+        [CLY]_view - "view" consent
+        [CLY]_orientation - "users" consent
+        [CLY]_push_action - "push" consent
+        [CLY]_action - "clicks" or "scroll" consent
+     */
+    var internalEventKeyEnums = {
+        NPS: '[CLY]_nps',
+        SURVEY: '[CLY]_survey',
+        STAR_RATING: '[CLY]_star_rating',
+        VIEW: '[CLY]_view',
+        ORIENTATION: '[CLY]_orientation',
+        PUSH_ACTION: '[CLY]_push_action',
+        ACTION: '[CLY]_action',
+    };
     //create object to store consents
     var consents = {};
     for (var feat = 0; feat < Countly.features.length; feat++) {
@@ -475,11 +493,40 @@ Countly.Bulk = Bulk;
     * @param {Object=} event.segmentation - object with segments key /values
     **/
     Countly.add_event = function(event) {
-        if (Countly.check_consent("events")) {
+        //initially no consent is given
+        var respectiveConsent = false;
+        //to match the internal events and their respective required consents. Sets respectiveConsent to true if the consent is given
+        switch (event.key) {
+        case internalEventKeyEnums.NPS:
+            respectiveConsent = Countly.check_consent('feedback');
+            break;
+        case internalEventKeyEnums.SURVEY:
+            respectiveConsent = Countly.check_consent('feedback');
+            break;
+        case internalEventKeyEnums.STAR_RATING:
+            respectiveConsent = Countly.check_consent('star-rating');
+            break;
+        case internalEventKeyEnums.VIEW:
+            respectiveConsent = Countly.check_consent('view');
+            break;
+        case internalEventKeyEnums.ORIENTATION:
+            respectiveConsent = Countly.check_consent('users');
+            break;
+        case internalEventKeyEnums.PUSH_ACTION:
+            respectiveConsent = Countly.check_consent('push');
+            break;
+        case internalEventKeyEnums.ACTION:
+            respectiveConsent = Countly.check_consent('clicks') || Countly.check_consent('scroll');
+            break;
+        default:
+            respectiveConsent = false;
+            respectiveConsent = Countly.check_consent('events');
+        }
+        //if consent is given adds event to the queue
+        if (respectiveConsent) {
             add_cly_events(event);
         }
     };
-
     /**
     *  Add events to event queue
     *  @memberof Countly._internals
@@ -749,7 +796,7 @@ Countly.Bulk = Bulk;
             if (Countly.check_consent("events")) {
                 var props = ["widget_id", "contactMe", "platform", "app_version", "rating", "email", "comment"];
                 var event = {
-                    key: "[CLY]_star_rating",
+                    key: internalEventKeyEnums.STAR_RATING,
                     count: 1,
                     segmentation: {}
                 };
@@ -944,7 +991,7 @@ Countly.Bulk = Bulk;
             //track pageview
             if (Countly.check_consent("views")) {
                 add_cly_events({
-                    "key": "[CLY]_view",
+                    "key": internalEventKeyEnums.VIEW,
                     "segmentation": segments
                 });
             }
@@ -1052,7 +1099,7 @@ Countly.Bulk = Bulk;
             //track pageview
             if (Countly.check_consent("views")) {
                 add_cly_events({
-                    "key": "[CLY]_view",
+                    "key": internalEventKeyEnums.VIEW,
                     "dur": getTimestamp() - lastViewTime,
                     "segmentation": segments
                 });


### PR DESCRIPTION
- Now event recording obeys respective consents
- Also added Enums
- Changelog entry
- Tested

![image](https://user-images.githubusercontent.com/62231246/143863404-a57ed6af-939d-4dc3-a9e2-8c9bdafc8c7b.png)
Here a log is triggered when event consent is activated for the custom event we add

![image](https://user-images.githubusercontent.com/62231246/143863521-dc1517b0-288e-4fd0-9183-d7d1feed912e.png)
Here event consent is given for the internal event, again triggered a log message
