### PR TITLE
[SDK-609] Storage bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 **/.DS_Store
 **/node_modules
-**/bulk_data
+bulk_data/**
 **/data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 21.11.0
 - !! Major breaking change !! Changing device ID without merging will now clear the current consent. Consent has to be given again after performing this action.
 - ! Minor breaking change ! After initialization, the logging/debugging mode can only be changed with `Countly.setLoggingEnabled` instead of `Countly.debug` now.
+- Fixed a bug where the SDK throws a `Bulk user storage exception` due to a missing folder
 - Increased the default max event batch size to 100.
 
 ## 20.11


### PR DESCRIPTION
Problem is directly experienced at npm version:
![sdk_609](https://user-images.githubusercontent.com/62231246/147399273-b3e2a830-cf83-4c60-a392-0c942576d5ac.png)
And it is reproducible at source code when `bulk_data` is manually erased, and it is resolved when it's manually restored again.

Looks like the core logic depends on the `bulk_data` to exist, but we do not ship it at our npm version . And that folder is not recreated if missing because `persist_queue` option is false by default to keep the queue in memory. Setting it to true during the init fixes the problems but a more general solution would be to ship the empty `bulk_data` with the next release, so I have changed the gitignore file to include the folder but exclude its content. 

