### PR TITLE
[SDK-595] Consent update logic

### DIFF
--- a/lib/countly-bulk-user.js
+++ b/lib/countly-bulk-user.js
@@ -43,7 +43,8 @@ function CountlyBulkUser(conf) {
     "use strict";
 
     var sessionStart = 0,
-        syncConsents = {},
+        syncConsents = cc.consentInitialState,
+        syncCount = 0,
         lastParams = {};
 
     /**
@@ -150,6 +151,7 @@ function CountlyBulkUser(conf) {
                 //this is core feature
                 if (consents[feature].optin !== true) {
                     syncConsents[feature] = true;
+                    syncCount++;
                     consents[feature].optin = true;
                     updateConsent();
                     setTimeout(function() {
@@ -202,6 +204,7 @@ function CountlyBulkUser(conf) {
                 //this is core feature
                 if (enforceConsentUpdate && consents[feature].optin !== false) {
                     syncConsents[feature] = false;
+                    syncCount++;
                     updateConsent();
                 }
             }
@@ -220,11 +223,12 @@ function CountlyBulkUser(conf) {
             consentTimer = null;
         }
         consentTimer = setTimeout(function() {
-            if (Object.keys(syncConsents).length) {
+            if (syncCount) {
                 //we have consents to sync, create request
                 conf.server.add_bulk_request([{consent: JSON.stringify(syncConsents)}]);
                 //clear consents that needs syncing
-                syncConsents = {};
+                syncConsents = cc.consentInitialState;
+                syncCount = 0;
             }
         }, 1000);
     };

--- a/lib/countly-bulk-user.js
+++ b/lib/countly-bulk-user.js
@@ -43,8 +43,6 @@ function CountlyBulkUser(conf) {
     "use strict";
 
     var sessionStart = 0,
-        syncConsents = cc.consentInitialState,
-        syncCount = 0,
         lastParams = {};
 
     /**
@@ -150,8 +148,6 @@ function CountlyBulkUser(conf) {
             else {
                 //this is core feature
                 if (consents[feature].optin !== true) {
-                    syncConsents[feature] = true;
-                    syncCount++;
                     consents[feature].optin = true;
                     updateConsent();
                     setTimeout(function() {
@@ -201,14 +197,15 @@ function CountlyBulkUser(conf) {
                 this.remove_consent_internal(consents[feature].features, enforceConsentUpdate);
             }
             else {
+                consents[feature].optin = false;
                 //this is core feature
                 if (enforceConsentUpdate && consents[feature].optin !== false) {
-                    syncConsents[feature] = false;
-                    syncCount++;
+
                     updateConsent();
                 }
             }
-            consents[feature].optin = false;
+            cc.log("Consent removal triggered.");
+
         }
         else {
             cc.log("No feature available for " + feature);
@@ -223,13 +220,17 @@ function CountlyBulkUser(conf) {
             consentTimer = null;
         }
         consentTimer = setTimeout(function() {
-            if (syncCount) {
-                //we have consents to sync, create request
-                conf.server.add_bulk_request([{consent: JSON.stringify(syncConsents)}]);
-                //clear consents that needs syncing
-                syncConsents = cc.consentInitialState;
-                syncCount = 0;
+            var consentMessage = {};
+            for (var i = 0; i < features.length; i++) {
+                if (consents[features[i]].optin === true) {
+                    consentMessage[features[i]] = true;
+                }
+                else {
+                    consentMessage[features[i]] = false;
+                }
             }
+            conf.server.add_bulk_request({consent: JSON.stringify(consentMessage)});
+            cc.log("Consent update request has been sent to the queue.");
         }, 1000);
     };
 

--- a/lib/countly-common.js
+++ b/lib/countly-common.js
@@ -24,11 +24,6 @@ var cc = {
         VERBOSE: '[VERBOSE] ',
     },
     /**
-     * This represents the initial state of the consents instead of an empty object.
-     * It provides a base for any changes in consents like addition or removal. 
-     */
-    consentInitialState: {"sessions": false, "events": false, "views": false, "crashes": false, "attribution": false, "users": false, "location": false, "star-rating": false, "apm": false, "feedback": false, "remote-config": false},
-    /**
      *  Get current timestamp
      *  @returns {number} unix timestamp in seconds
      */

--- a/lib/countly-common.js
+++ b/lib/countly-common.js
@@ -23,7 +23,11 @@ var cc = {
         DEBUG: '[DEBUG] ',
         VERBOSE: '[VERBOSE] ',
     },
-
+    /**
+     * This represents the initial state of the consents instead of an empty object.
+     * It provides a base for any changes in consents like addition or removal. 
+     */
+    consentInitialState: {"sessions": false, "events": false, "views": false, "crashes": false, "attribution": false, "users": false, "location": false, "star-rating": false, "apm": false, "feedback": false, "remote-config": false},
     /**
      *  Get current timestamp
      *  @returns {number} unix timestamp in seconds

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -387,7 +387,7 @@ Countly.Bulk = Bulk;
                 }
             }
             toRequestQueue({consent: JSON.stringify(consentMessage)});
-            cc.log("Consent removal request has been sent to the queue.");
+            cc.log("Consent update request has been sent to the queue.");
         }, 1000);
     };
 

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -67,8 +67,6 @@ Countly.Bulk = Bulk;
         readyToProcess = true,
         trackTime = true,
         metrics = {},
-        syncConsents = cc.consentInitialState,
-        syncCount = 0,
         lastParams = {},
         startTime,
         __data = {};
@@ -302,8 +300,6 @@ Countly.Bulk = Bulk;
             else {
                 //this is core feature
                 if (consents[feature].optin !== true) {
-                    syncConsents[feature] = true;
-                    syncCount++;
                     consents[feature].optin = true;
                     updateConsent();
                     setTimeout(function() {
@@ -359,14 +355,12 @@ Countly.Bulk = Bulk;
 
             }
             else {
+                consents[feature].optin = false;
                 //this is core feature
                 if (enforceConsentUpdate && consents[feature].optin !== false) {
-                    syncConsents[feature] = false;
-                    syncCount++;
                     updateConsent();
                 }
             }
-            consents[feature].optin = false;
             cc.log("Consent removal triggered.");
 
         }
@@ -383,14 +377,17 @@ Countly.Bulk = Bulk;
             consentTimer = null;
         }
         consentTimer = setTimeout(function() {
-            if (syncCount) {
-                //we have consents to sync, create request
-                toRequestQueue({consent: JSON.stringify(syncConsents)});
-                cc.log("Consent removal request has been sent to the queue.");
-                //clear consents that needs syncing
-                syncConsents = cc.consentInitialState;
-                syncCount = 0;
+            var consentMessage = {};
+            for (var i = 0; i < Countly.features.length; i++) {
+                if (consents[Countly.features[i]].optin === true) {
+                    consentMessage[Countly.features[i]] = true;
+                }
+                else {
+                    consentMessage[Countly.features[i]] = false;
+                }
             }
+            toRequestQueue({consent: JSON.stringify(consentMessage)});
+            cc.log("Consent removal request has been sent to the queue.");
         }, 1000);
     };
 
@@ -1179,16 +1176,6 @@ Countly.Bulk = Bulk;
         if (requestQueue.length > 0 && readyToProcess && cc.getTimestamp() > failTimeout) {
             readyToProcess = false;
             var params = requestQueue.shift();
-            //check if any consent changed to sync
-            if (syncCount) {
-                if (consentTimer) {
-                    clearTimeout(consentTimer);
-                    consentTimer = null;
-                }
-                params.consent = JSON.stringify(syncConsents);
-                syncConsents = cc.consentInitialState;
-                syncCount = 0;
-            }
             cc.log("Processing request", params);
             makeRequest(Countly.url, apiPath, params, function(err, res) {
                 cc.log("Request Finished", res, err);

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -67,7 +67,8 @@ Countly.Bulk = Bulk;
         readyToProcess = true,
         trackTime = true,
         metrics = {},
-        syncConsents = {},
+        syncConsents = cc.consentInitialState,
+        syncCount = 0,
         lastParams = {},
         startTime,
         __data = {};
@@ -302,6 +303,7 @@ Countly.Bulk = Bulk;
                 //this is core feature
                 if (consents[feature].optin !== true) {
                     syncConsents[feature] = true;
+                    syncCount++;
                     consents[feature].optin = true;
                     updateConsent();
                     setTimeout(function() {
@@ -360,6 +362,7 @@ Countly.Bulk = Bulk;
                 //this is core feature
                 if (enforceConsentUpdate && consents[feature].optin !== false) {
                     syncConsents[feature] = false;
+                    syncCount++;
                     updateConsent();
                 }
             }
@@ -380,12 +383,13 @@ Countly.Bulk = Bulk;
             consentTimer = null;
         }
         consentTimer = setTimeout(function() {
-            if (Object.keys(syncConsents).length) {
+            if (syncCount) {
                 //we have consents to sync, create request
                 toRequestQueue({consent: JSON.stringify(syncConsents)});
                 cc.log("Consent removal request has been sent to the queue.");
                 //clear consents that needs syncing
-                syncConsents = {};
+                syncConsents = cc.consentInitialState;
+                syncCount = 0;
             }
         }, 1000);
     };
@@ -1175,14 +1179,15 @@ Countly.Bulk = Bulk;
         if (requestQueue.length > 0 && readyToProcess && cc.getTimestamp() > failTimeout) {
             readyToProcess = false;
             var params = requestQueue.shift();
-            //check if any consent to sync
-            if (Object.keys(syncConsents).length) {
+            //check if any consent changed to sync
+            if (syncCount) {
                 if (consentTimer) {
                     clearTimeout(consentTimer);
                     consentTimer = null;
                 }
                 params.consent = JSON.stringify(syncConsents);
-                syncConsents = {};
+                syncConsents = cc.consentInitialState;
+                syncCount = 0;
             }
             cc.log("Processing request", params);
             makeRequest(Countly.url, apiPath, params, function(err, res) {


### PR DESCRIPTION
State of all consent values needed to be sent during the update. So I created an object called `initialConsentState` at commons module. There, every consent is set to `false`. I changed the `syncConsent` from being an empty object to `cc.initialConsentState`, where updates works as a modification only. After sending this object to the queue, instead of emptying it, I've set it to the initial value again. To not update/send the values unnecessarily, previously, there was an 'if check' to see if `syncConsent` had any value (length) as it was an empty object initially. As `initialConsentState` fixed the `syncConsent`'s length to a constant value, that 'if check' become invalid.  Instead I have used a variable called `syncCounter` and increased its value if any consent value changes, and then return it to 0 after sending the consents to the queue. Tested and working.     