### PR TITLE
chore(deps): override brace-expansion and js-yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -811,9 +811,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2849,10 +2849,11 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3353,9 +3354,9 @@
       "dev": true
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3421,10 +3422,21 @@
       }
     },
     "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -41,5 +41,11 @@
     "markdownlint": "0.26.0",
     "mocha": "11.7.1",
     "nyc": "17.1.0"
+  },
+  "overrides": {
+    "brace-expansion@^1.0.0": "^1.1.16",
+    "brace-expansion@^2.0.0": "^2.1.2",
+    "js-yaml@^3.0.0": "^3.15.0",
+    "js-yaml@^4.0.0": "^4.3.0"
   }
 }


### PR DESCRIPTION
Both advisories reach this repo only through `devDependencies`, so nothing that ships to SDK consumers is affected. `overrides` in a published package's manifest applies to this repo's own installs, not to downstream projects.

| Package | Advisory | Found | Pinned |
|---|---|---|---|
| `brace-expansion` | GHSA-3jxr-9vmj-r5cp | 1.1.12 (top level), 2.0.2 (under `mocha`) | `^1.1.16`, `^2.1.2` |
| `js-yaml` | GHSA-52cp-r559-cp3m | 3.14.1 (top level, via `eslint`), 4.1.0 (under `mocha`) | `^3.15.0`, `^4.3.0` |

Each advisory patches its major lines separately, so both packages get one range-keyed override per major rather than forcing a single version across a major boundary.

## Resolution

Lockfile changes are confined to these two packages; no other version moved:

- `brace-expansion` 1.1.12 → 1.1.18, and 2.0.2 → 2.1.4 under `mocha`
- `js-yaml` 3.14.1 → 3.15.1, and 4.1.0 → 4.3.1 under `mocha`

Both files keep their existing CRLF line endings, so the diff is only the changed entries.

## Verification

- `npm ci` succeeds (449 packages).
- Re-scanned the lockfile against the advisory version ranges: 0 remaining matches.
- `eslint --ignore-path .eslintignore .` — the `pretest` step, which consumes both packages — passes clean.
- Full mocha suite: **94 passing**.

Targets `staging`, matching how this repo takes changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
